### PR TITLE
Fix code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/app/api/routes/user.py
+++ b/app/api/routes/user.py
@@ -1,5 +1,6 @@
 from aws import db
 from flask import Blueprint, abort, jsonify, request
+import logging
 
 bp_user = Blueprint("user", __name__, url_prefix="/user")
 
@@ -11,7 +12,8 @@ def create_user():
         response = db.register_user(data["name"])
         return jsonify({"message": "User created.", "user_id": response}), 201
     except Exception as e:
-        return jsonify({"error": str(e)}), 400
+        logging.error("Error creating user: %s", str(e))
+        return jsonify({"error": "An internal error has occurred."}), 400
 
 
 @bp_user.route("/", methods=["GET"])


### PR DESCRIPTION
Fixes [https://github.com/LiamTownsley2/Security-Access/security/code-scanning/10](https://github.com/LiamTownsley2/Security-Access/security/code-scanning/10)

To fix the problem, we should avoid returning the exception message directly to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

- Modify the `create_user` function to log the exception message and return a generic error message.
- Add an import for the `logging` module to handle logging the exception.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
